### PR TITLE
Add clang-format CI check

### DIFF
--- a/.github/workflows/arcanum-ci.yml
+++ b/.github/workflows/arcanum-ci.yml
@@ -106,10 +106,7 @@ jobs:
       - name: Check formatting
         working-directory: arcanum
         run: |
-          find . -type f \
-              \( -name '*.h' -o -name '*.hpp' -o -name '*.cpp' \
-                 -o -name '*.c' -o -name '*.cc' \) \
-              -not -path './build/*' -print0 \
+          git ls-files -z '*.h' '*.hpp' '*.cpp' '*.c' '*.cc' \
             | xargs -0 --no-run-if-empty clang-format --dry-run --Werror
 
   docs:


### PR DESCRIPTION
## Summary
- Adds a `clang-format` job to `arcanum-ci.yml` that runs `clang-format --dry-run --Werror` on every tracked C/C++ file under `arcanum/`.
- Runs inside the existing `ghcr.io/{owner}/{repo}/arcanum-ci:latest` image, which already ships `clang-format-22` via update-alternatives — no apt install per run.
- Job is standalone (no `needs:`) so format violations surface even when the build is broken.

Closes #31.

## Out of scope
- clang-tidy (follow-up PR) — will also enable `llvm-header-guard` for include-guard validation.
- codespell spell check (follow-up PR).

## Test plan
- [x] Verified locally: same `find | xargs clang-format` command passes on the tracked files.
- [ ] CI run on this PR succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)