### PR TITLE
Add clang-tidy + include-guard CI checks

### DIFF
--- a/.github/workflows/arcanum-ci.yml
+++ b/.github/workflows/arcanum-ci.yml
@@ -71,7 +71,7 @@ jobs:
       - name: Run clang-tidy
         working-directory: arcanum
         run: |
-          find . -type f -name '*.cpp' -not -path './build/*' -print0 \
+          git ls-files -z '*.cpp' \
             | xargs -0 --no-run-if-empty \
                 clang-tidy -p build/dev --quiet --warnings-as-errors='*'
 

--- a/arcanum/scripts/check-include-guards.sh
+++ b/arcanum/scripts/check-include-guards.sh
@@ -10,8 +10,7 @@ set -euo pipefail
 
 fail=0
 while IFS= read -r -d '' file; do
-  rel="${file#./}"
-  expected=$(echo "$rel" | tr '[:lower:]/.' '[:upper:]__')
+  expected=$(echo "$file" | tr '[:lower:]/.' '[:upper:]__')
   ifndef=$(grep -m1 '^#ifndef ' "$file" | awk '{print $2}' || true)
   define=$(grep -m1 '^#define ' "$file" | awk '{print $2}' || true)
   if [[ "$ifndef" != "$expected" || "$define" != "$expected" ]]; then
@@ -21,6 +20,6 @@ while IFS= read -r -d '' file; do
     echo "  #define:  ${define:-<missing>}"
     fail=1
   fi
-done < <(find . -name '*.h' -not -path './build/*' -print0)
+done < <(git ls-files -z '*.h')
 
 exit $fail


### PR DESCRIPTION
## Summary
- Adds two lint jobs to `arcanum-ci.yml`, both running in the existing `arcanum-ci` container image:
  - **clang-tidy**: configures + builds TableGen targets (so generated `.inc` files exist), then runs `clang-tidy --warnings-as-errors='*'` on every tracked `.cpp` under `arcanum/`. Uses ccache.
  - **header-guards**: runs `arcanum/scripts/check-include-guards.sh`, which asserts every `.h` has a guard matching its arcanum-relative path uppercased (e.g. `ecsl/IR/ECSLDialect.h` → `ECSL_IR_ECSLDIALECT_H`).

Not using clang-tidy's built-in `llvm-header-guard`: it computes the expected guard from the file's **absolute** path and would demand `WORKSPACES_AD_ADAS_ARCANUM_ECSL_IR_ECSLOPS_H` for out-of-tree projects without a module map.

Closes #33.

## Out of scope
- codespell spell check (separate PR)

## Test plan
- [x] clang-tidy command passes locally on the current tree.
- [x] `check-include-guards.sh` passes locally; verified it flags wrong guards (tested with `WRONG_GUARD` in a temp `.h`).
- [ ] CI run on this PR exercises both jobs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)