### PR TITLE
Switch warnings to -Weverything + exclude list

### DIFF
--- a/arcanum/cmake/Warnings.cmake
+++ b/arcanum/cmake/Warnings.cmake
@@ -1,23 +1,24 @@
 # Warnings.cmake - Arcanum compiler warning policy.
 #
-# Applied globally via add_compile_options(). Layered on top of the
-# warnings LLVM's HandleLLVMOptions already enables
-# (-Wall -Wextra -Wsuggest-override -Wmisleading-indentation, etc.).
+# Turn on every warning clang knows about (-Weverything), then disable
+# the ones we consciously don't want. Applied globally via
+# add_compile_options(); layered on top of the warnings LLVM's
+# HandleLLVMOptions already enables (-Wall -Wextra, etc.).
 #
-# LLVM/MLIR headers are treated as SYSTEM includes elsewhere in the
-# top-level CMakeLists.txt, so these flags do not fire on third-party
-# code.
+# LLVM/MLIR headers are treated as SYSTEM includes in the top-level
+# CMakeLists.txt, so third-party headers do not fire these flags.
 
 option(ARCANUM_WERROR "Treat warnings as errors" ON)
 
 set(ARCANUM_WARNING_FLAGS
-  -Wshadow
-  -Wold-style-cast
-  -Wcast-align
-  -Woverloaded-virtual
-  -Wformat=2
-  -Wnull-dereference
-  -Wdouble-promotion
+  -Wall
+  -Wextra
+  -Weverything
+
+  # --- Exclusions ---
+  # We target C++17, so C++98-compat complaints are noise.
+  -Wno-c++98-compat
+  -Wno-c++98-compat-pedantic
 )
 
 add_compile_options(${ARCANUM_WARNING_FLAGS})


### PR DESCRIPTION
## Summary
Replaces the curated opt-in warning set (from #39) with an opt-out model in `arcanum/cmake/Warnings.cmake`:
- Enable **every** clang warning via `-Weverything`.
- Selectively disable with `-Wno-*`, each with an inline comment explaining why.

Current exclusions:
- `-Wno-c++98-compat`, `-Wno-c++98-compat-pedantic` — we target C++17+.

`ARCANUM_WERROR` toggle and SYSTEM-include treatment of LLVM/MLIR (from #39) are unchanged.

Closes #40.

## Why opt-out over opt-in
- New warnings in future clang releases apply automatically.
- Every exclusion is explicitly documented; no silent "we forgot to add this flag".

## Test plan
- [x] `cmake --preset dev` + `cmake --build build/dev --target MLIRECSL arcanum-test-ecsl-register` builds clean on this branch.
- [ ] CI build jobs (dev + release) stay green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)