### PR TITLE
Register empty testgen MLIR dialect with TableGen

### DIFF
--- a/arcanum/test/CMakeLists.txt
+++ b/arcanum/test/CMakeLists.txt
@@ -3,8 +3,9 @@
 # Subdirectories:
 #   examples/  - Example input files (future)
 #   ecsl/      - ECSL dialect unit tests
-#   testgen/   - TestGen pass tests (future)
+#   testgen/   - TestGen dialect unit tests
 #   verify/    - Verification pass tests (future)
 #   e2e/       - End-to-end integration tests (future)
 
 add_subdirectory(ecsl)
+add_subdirectory(testgen)

--- a/arcanum/test/testgen/CMakeLists.txt
+++ b/arcanum/test/testgen/CMakeLists.txt
@@ -1,0 +1,14 @@
+# test/testgen/ - TestGen dialect unit tests
+
+add_executable(arcanum-test-testgen-register
+  RegisterDialect.cpp
+)
+
+target_link_libraries(arcanum-test-testgen-register
+  PRIVATE
+  MLIRTestGen
+)
+
+add_test(NAME testgen-register
+  COMMAND arcanum-test-testgen-register
+)

--- a/arcanum/test/testgen/RegisterDialect.cpp
+++ b/arcanum/test/testgen/RegisterDialect.cpp
@@ -1,0 +1,24 @@
+// Smoke test: loads the TestGen dialect into an MLIRContext and
+// verifies its registered namespace.
+
+#include "testgen/IR/TestGenDialect.h"
+
+#include "mlir/IR/MLIRContext.h"
+
+#include "llvm/Support/raw_ostream.h"
+
+int main() {
+  mlir::MLIRContext ctx;
+  ctx.loadDialect<testgen::TestGenDialect>();
+  const mlir::Dialect *dialect = ctx.getOrLoadDialect("testgen");
+  if (dialect == nullptr) {
+    llvm::errs() << "failed to load testgen dialect\n";
+    return 1;
+  }
+  if (dialect->getNamespace() != "testgen") {
+    llvm::errs() << "unexpected dialect namespace: " << dialect->getNamespace()
+                 << "\n";
+    return 1;
+  }
+  return 0;
+}

--- a/arcanum/testgen/CMakeLists.txt
+++ b/arcanum/testgen/CMakeLists.txt
@@ -1,6 +1,8 @@
 # testgen/ - Test Generation Dialect and Passes
 #
-# Components:
+# Subdirectories:
 #   IR/       - TestGen dialect definition (.td + C++)
-#   Passes/   - BoundaryValuePass
-#   CodeGen/  - Google Test code generator
+#   Passes/   - BoundaryValuePass (future)
+#   CodeGen/  - Google Test code generator (future)
+
+add_subdirectory(IR)

--- a/arcanum/testgen/IR/CMakeLists.txt
+++ b/arcanum/testgen/IR/CMakeLists.txt
@@ -1,0 +1,20 @@
+# testgen/IR/ - TestGen dialect IR (TableGen + C++)
+
+set(LLVM_TARGET_DEFINITIONS TestGenOps.td)
+mlir_tablegen(TestGenOpsDialect.h.inc -gen-dialect-decls -dialect=testgen)
+mlir_tablegen(TestGenOpsDialect.cpp.inc -gen-dialect-defs -dialect=testgen)
+mlir_tablegen(TestGenOps.h.inc -gen-op-decls)
+mlir_tablegen(TestGenOps.cpp.inc -gen-op-defs)
+add_public_tablegen_target(TestGenOpsIncGen)
+
+add_mlir_dialect_library(MLIRTestGen
+  TestGenDialect.cpp
+  TestGenOps.cpp
+
+  DEPENDS
+  TestGenOpsIncGen
+
+  LINK_LIBS PUBLIC
+  MLIRIR
+  MLIRSupport
+)

--- a/arcanum/testgen/IR/TestGenDialect.cpp
+++ b/arcanum/testgen/IR/TestGenDialect.cpp
@@ -1,0 +1,14 @@
+#include "testgen/IR/TestGenDialect.h"
+
+#include "testgen/IR/TestGenOps.h" // IWYU pragma: keep (used via GET_OP_LIST)
+
+using namespace testgen;
+
+#include "testgen/IR/TestGenOpsDialect.cpp.inc"
+
+void TestGenDialect::initialize() {
+  addOperations<
+#define GET_OP_LIST
+#include "testgen/IR/TestGenOps.cpp.inc"
+      >();
+}

--- a/arcanum/testgen/IR/TestGenDialect.h
+++ b/arcanum/testgen/IR/TestGenDialect.h
@@ -1,0 +1,13 @@
+/// \file
+/// Declares the TestGen MLIR dialect class.
+
+#ifndef TESTGEN_IR_TESTGENDIALECT_H
+#define TESTGEN_IR_TESTGENDIALECT_H
+
+#include "mlir/IR/Dialect.h"
+
+// clang-format off
+#include "testgen/IR/TestGenOpsDialect.h.inc"
+// clang-format on
+
+#endif // TESTGEN_IR_TESTGENDIALECT_H

--- a/arcanum/testgen/IR/TestGenDialect.td
+++ b/arcanum/testgen/IR/TestGenDialect.td
@@ -1,0 +1,24 @@
+//===- TestGenDialect.td - TestGen dialect definition -----*- tablegen -*-===//
+//
+// Defines the `testgen` MLIR dialect. This is the dialect shell only;
+// no operations are declared here yet.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef TESTGEN_IR_TESTGEN_DIALECT_TD
+#define TESTGEN_IR_TESTGEN_DIALECT_TD
+
+include "mlir/IR/OpBase.td"
+
+def TestGen_Dialect : Dialect {
+  let name = "testgen";
+  let summary = "TestGen dialect for Arcanum";
+  let description = [{
+    The TestGen dialect represents test-case generation artifacts in
+    MLIR. It currently contains no operations; it exists to validate
+    the dialect registration pipeline.
+  }];
+  let cppNamespace = "::testgen";
+}
+
+#endif // TESTGEN_IR_TESTGEN_DIALECT_TD

--- a/arcanum/testgen/IR/TestGenOps.cpp
+++ b/arcanum/testgen/IR/TestGenOps.cpp
@@ -1,0 +1,6 @@
+#include "testgen/IR/TestGenOps.h"
+
+#include "testgen/IR/TestGenDialect.h" // IWYU pragma: keep (used by generated .inc)
+
+#define GET_OP_CLASSES
+#include "testgen/IR/TestGenOps.cpp.inc"

--- a/arcanum/testgen/IR/TestGenOps.h
+++ b/arcanum/testgen/IR/TestGenOps.h
@@ -1,0 +1,14 @@
+/// \file
+/// Declares the TestGen dialect operation classes.
+
+#ifndef TESTGEN_IR_TESTGENOPS_H
+#define TESTGEN_IR_TESTGENOPS_H
+
+#include "mlir/IR/BuiltinTypes.h"
+#include "mlir/IR/Dialect.h"
+#include "mlir/IR/OpDefinition.h"
+
+#define GET_OP_CLASSES
+#include "testgen/IR/TestGenOps.h.inc"
+
+#endif // TESTGEN_IR_TESTGENOPS_H

--- a/arcanum/testgen/IR/TestGenOps.td
+++ b/arcanum/testgen/IR/TestGenOps.td
@@ -1,0 +1,18 @@
+//===- TestGenOps.td - TestGen dialect operations ---------*- tablegen -*-===//
+//
+// TableGen source for TestGen dialect operations. No operations are
+// defined yet; this file exists so the TableGen to C++ pipeline can
+// be exercised.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef TESTGEN_IR_TESTGEN_OPS_TD
+#define TESTGEN_IR_TESTGEN_OPS_TD
+
+include "testgen/IR/TestGenDialect.td"
+include "mlir/IR/OpBase.td"
+
+class TestGen_Op<string mnemonic, list<Trait> traits = []>
+    : Op<TestGen_Dialect, mnemonic, traits>;
+
+#endif // TESTGEN_IR_TESTGEN_OPS_TD


### PR DESCRIPTION
## Summary
- Adds the `testgen` MLIR dialect shell under `testgen/IR/`: TableGen sources (`TestGenDialect.td`, `TestGenOps.td`), generated dialect/op headers, C++ registration, and CMake wiring.
- Adds `arcanum-test-testgen-register` CTest target that loads `TestGenDialect` into an `MLIRContext` and verifies its namespace.
- Mirrors the ecsl dialect shell pattern from #24 exactly.
- No ops yet; PR validates the TableGen → C++ pipeline.

Closes #4.

## Test plan
- [x] `cmake --build build/dev --target MLIRTestGen arcanum-test-testgen-register` builds clean.
- [x] `ctest -R testgen-register` passes.
- [x] clang-format, clang-tidy, header-guards, codespell, doxygen all clean.
- [x] Full `cmake --build build/dev` + `ctest` passes (2/2 tests green).

🤖 Generated with [Claude Code](https://claude.com/claude-code)