### PR TITLE
Implement ECSL contract comment parser

### DIFF
--- a/arcanum/.clang-tidy
+++ b/arcanum/.clang-tidy
@@ -14,6 +14,11 @@ WarningsAsErrors: ''
 HeaderFilterRegex: '(ecsl|parser|testgen|verify|tools)/.*\.h$'
 
 CheckOptions:
+  # Plain data structs with all-public members are idiomatic; don't
+  # demand private fields + getters/setters on them.
+  - key: misc-non-private-member-variables-in-classes.IgnoreClassesWithAllMemberVariablesBeingPublic
+    value: 'true'
+
   # --- Types: CamelCase (LLVM standard) ---
   - key: readability-identifier-naming.ClassCase
     value: CamelCase
@@ -73,6 +78,8 @@ CheckOptions:
     value: camelBack
   - key: readability-identifier-naming.PrivateMemberCase
     value: camelBack
+  - key: readability-identifier-naming.PrivateMemberSuffix
+    value: '_'
 
   # --- Constants: camelBack for locals, CamelCase for true constants ---
   # A plain `const T x` in a function is still a variable, so use

--- a/arcanum/cmake/Warnings.cmake
+++ b/arcanum/cmake/Warnings.cmake
@@ -19,6 +19,17 @@ set(ARCANUM_WARNING_FLAGS
   # We target C++17, so C++98-compat complaints are noise.
   -Wno-c++98-compat
   -Wno-c++98-compat-pedantic
+
+  # -Wswitch-default demands a `default:` label on every switch, even
+  # ones that already cover every enumerator; that contradicts the
+  # more useful -Wcovered-switch-default, which flags unreachable
+  # default labels. Keep the latter, drop the former.
+  -Wno-switch-default
+
+  # -Wpadded fires on any struct the compiler pads for alignment,
+  # which is essentially every non-trivial struct on x86-64. LLVM and
+  # most modern C++ codebases disable it.
+  -Wno-padded
 )
 
 add_compile_options(${ARCANUM_WARNING_FLAGS})

--- a/arcanum/parser/CMakeLists.txt
+++ b/arcanum/parser/CMakeLists.txt
@@ -2,4 +2,12 @@
 #
 # Components:
 #   ECSLParser   - ECSL annotation parser
-#   ClangBridge  - Clang AST to ecsl MLIR dialect lowering
+#   ClangBridge  - Clang AST to ecsl MLIR dialect lowering (future)
+
+add_library(ArcanumParser STATIC
+  ECSLParser.cpp
+)
+
+target_include_directories(ArcanumParser PUBLIC
+  ${PROJECT_SOURCE_DIR}
+)

--- a/arcanum/parser/ECSLParser.cpp
+++ b/arcanum/parser/ECSLParser.cpp
@@ -1,0 +1,641 @@
+#include "parser/ECSLParser.h"
+
+#include <cctype>
+#include <cstddef>
+#include <cstdint>
+#include <memory>
+#include <optional>
+#include <sstream>
+#include <string>
+#include <string_view>
+#include <type_traits>
+#include <utility>
+#include <variant>
+#include <vector>
+
+namespace arcanum::parser {
+
+namespace {
+
+//===----------------------------------------------------------------------===//
+// Tokens
+//===----------------------------------------------------------------------===//
+
+enum class TokKind : std::uint8_t {
+  // Keywords
+  KwRequires,
+  KwEnsures,
+  KwAssigns,
+  KwResult,
+  KwNothing,
+  // Atoms
+  Ident,
+  IntLit,
+  // Punctuation
+  LParen,
+  RParen,
+  Semi,
+  // Operators
+  EqEq,
+  BangEq,
+  Lt,
+  Le,
+  Gt,
+  Ge,
+  Plus,
+  Minus,
+  Star,
+  Slash,
+  Percent,
+  Bang,
+  AmpAmp,
+  PipePipe,
+  // Control
+  Eof,
+  Error,
+};
+
+struct Token {
+  TokKind kind = TokKind::Eof;
+  std::string text;
+  SourceLoc loc;
+};
+
+class Lexer {
+public:
+  explicit Lexer(std::string_view input) : input_(input) {}
+
+  std::vector<Token> tokenize(std::vector<ParseError> &errors) {
+    std::vector<Token> out;
+    while (true) {
+      skipWhitespace();
+      Token tok = lexOne();
+      if (tok.kind == TokKind::Error) {
+        errors.push_back({std::move(tok.text), tok.loc});
+        continue;
+      }
+      const bool done = tok.kind == TokKind::Eof;
+      out.push_back(std::move(tok));
+      if (done) {
+        break;
+      }
+    }
+    return out;
+  }
+
+private:
+  Token lexOne() {
+    if (atEnd()) {
+      return makeAt(TokKind::Eof, "", loc_);
+    }
+    const SourceLoc start = loc_;
+    const char c = peek();
+
+    if ((std::isalpha(static_cast<unsigned char>(c)) != 0) || c == '_') {
+      return lexIdentifier(start);
+    }
+    if (std::isdigit(static_cast<unsigned char>(c)) != 0) {
+      return lexInteger(start);
+    }
+    if (c == '\\') {
+      return lexBackslashKeyword(start);
+    }
+    return lexOperatorOrPunct(start);
+  }
+
+  Token lexIdentifier(SourceLoc start) {
+    std::string text;
+    while (!atEnd()) {
+      const char c = peek();
+      const bool isWord =
+          (std::isalnum(static_cast<unsigned char>(c)) != 0) || c == '_';
+      if (!isWord) {
+        break;
+      }
+      text.push_back(c);
+      advance();
+    }
+    if (text == "requires") {
+      return makeAt(TokKind::KwRequires, std::move(text), start);
+    }
+    if (text == "ensures") {
+      return makeAt(TokKind::KwEnsures, std::move(text), start);
+    }
+    if (text == "assigns") {
+      return makeAt(TokKind::KwAssigns, std::move(text), start);
+    }
+    return makeAt(TokKind::Ident, std::move(text), start);
+  }
+
+  Token lexInteger(SourceLoc start) {
+    std::string text;
+    while (!atEnd() &&
+           (std::isdigit(static_cast<unsigned char>(peek())) != 0)) {
+      text.push_back(peek());
+      advance();
+    }
+    return makeAt(TokKind::IntLit, std::move(text), start);
+  }
+
+  Token lexBackslashKeyword(SourceLoc start) {
+    advance(); // consume '\'
+    std::string text;
+    while (!atEnd()) {
+      const char c = peek();
+      const bool isWord =
+          (std::isalpha(static_cast<unsigned char>(c)) != 0) || c == '_';
+      if (!isWord) {
+        break;
+      }
+      text.push_back(c);
+      advance();
+    }
+    if (text == "result") {
+      return makeAt(TokKind::KwResult, "\\result", start);
+    }
+    if (text == "nothing") {
+      return makeAt(TokKind::KwNothing, "\\nothing", start);
+    }
+    return makeAt(TokKind::Error, "unknown backslash keyword: \\" + text,
+                  start);
+  }
+
+  Token lexOperatorOrPunct(SourceLoc start) {
+    const char c = peek();
+    advance();
+    switch (c) {
+    case '(':
+      return makeAt(TokKind::LParen, "(", start);
+    case ')':
+      return makeAt(TokKind::RParen, ")", start);
+    case ';':
+      return makeAt(TokKind::Semi, ";", start);
+    case '+':
+      return makeAt(TokKind::Plus, "+", start);
+    case '-':
+      return makeAt(TokKind::Minus, "-", start);
+    case '*':
+      return makeAt(TokKind::Star, "*", start);
+    case '/':
+      return makeAt(TokKind::Slash, "/", start);
+    case '%':
+      return makeAt(TokKind::Percent, "%", start);
+    case '=':
+      if (!atEnd() && peek() == '=') {
+        advance();
+        return makeAt(TokKind::EqEq, "==", start);
+      }
+      return makeAt(TokKind::Error, "unexpected '='", start);
+    case '!':
+      if (!atEnd() && peek() == '=') {
+        advance();
+        return makeAt(TokKind::BangEq, "!=", start);
+      }
+      return makeAt(TokKind::Bang, "!", start);
+    case '<':
+      if (!atEnd() && peek() == '=') {
+        advance();
+        return makeAt(TokKind::Le, "<=", start);
+      }
+      return makeAt(TokKind::Lt, "<", start);
+    case '>':
+      if (!atEnd() && peek() == '=') {
+        advance();
+        return makeAt(TokKind::Ge, ">=", start);
+      }
+      return makeAt(TokKind::Gt, ">", start);
+    case '&':
+      if (!atEnd() && peek() == '&') {
+        advance();
+        return makeAt(TokKind::AmpAmp, "&&", start);
+      }
+      return makeAt(TokKind::Error, "unexpected '&'", start);
+    case '|':
+      if (!atEnd() && peek() == '|') {
+        advance();
+        return makeAt(TokKind::PipePipe, "||", start);
+      }
+      return makeAt(TokKind::Error, "unexpected '|'", start);
+    default:
+      return makeAt(TokKind::Error,
+                    std::string("unexpected character: '") + c + "'", start);
+    }
+  }
+
+  void skipWhitespace() {
+    while (!atEnd()) {
+      const char c = peek();
+      if (c != ' ' && c != '\t' && c != '\r' && c != '\n') {
+        break;
+      }
+      advance();
+    }
+  }
+
+  [[nodiscard]] bool atEnd() const { return pos_ >= input_.size(); }
+  [[nodiscard]] char peek() const { return input_[pos_]; }
+
+  void advance() {
+    if (atEnd()) {
+      return;
+    }
+    if (input_[pos_] == '\n') {
+      ++loc_.line;
+      loc_.col = 1;
+    } else {
+      ++loc_.col;
+    }
+    ++pos_;
+  }
+
+  static Token makeAt(TokKind kind, std::string text, SourceLoc loc) {
+    Token tok;
+    tok.kind = kind;
+    tok.text = std::move(text);
+    tok.loc = loc;
+    return tok;
+  }
+
+  std::string_view input_;
+  std::size_t pos_ = 0;
+  SourceLoc loc_;
+};
+
+//===----------------------------------------------------------------------===//
+// Parser
+//===----------------------------------------------------------------------===//
+
+// Recursive-descent parser: mutually recursive by design.
+// NOLINTBEGIN(misc-no-recursion)
+class Parser {
+public:
+  Parser(std::vector<Token> tokens, std::vector<ParseError> &errors)
+      : tokens_(std::move(tokens)), errors_(errors) {}
+
+  std::vector<Clause> parseClauses() {
+    std::vector<Clause> clauses;
+    unsigned index = 0;
+    while (current().kind != TokKind::Eof) {
+      if (auto clause = parseClause(index)) {
+        clauses.push_back(std::move(*clause));
+        ++index;
+      } else {
+        syncToNextClause();
+      }
+    }
+    return clauses;
+  }
+
+private:
+  std::optional<Clause> parseClause(unsigned index) {
+    const Token startTok = current();
+    Clause clause;
+    clause.loc = startTok.loc;
+    clause.index = index;
+
+    if (startTok.kind == TokKind::KwRequires) {
+      clause.kind = ClauseKind::Requires;
+      advance();
+      clause.predicate = parsePredicate();
+    } else if (startTok.kind == TokKind::KwEnsures) {
+      clause.kind = ClauseKind::Ensures;
+      advance();
+      clause.predicate = parsePredicate();
+    } else if (startTok.kind == TokKind::KwAssigns) {
+      clause.kind = ClauseKind::AssignsNothing;
+      advance();
+      if (!expect(TokKind::KwNothing, "expected '\\nothing' after 'assigns'")) {
+        return std::nullopt;
+      }
+    } else {
+      reportAt("expected 'requires', 'ensures', or 'assigns'", startTok.loc);
+      return std::nullopt;
+    }
+
+    if (!expect(TokKind::Semi, "expected ';' at end of clause")) {
+      return std::nullopt;
+    }
+    return clause;
+  }
+
+  // predicate := logical_or
+  ExprPtr parsePredicate() { return parseLogicalOr(); }
+
+  ExprPtr parseLogicalOr() {
+    ExprPtr lhs = parseLogicalAnd();
+    while (current().kind == TokKind::PipePipe) {
+      const SourceLoc loc = current().loc;
+      advance();
+      ExprPtr rhs = parseLogicalAnd();
+      lhs =
+          makeBinary(BinaryOp::LogicalOr, std::move(lhs), std::move(rhs), loc);
+    }
+    return lhs;
+  }
+
+  ExprPtr parseLogicalAnd() {
+    ExprPtr lhs = parseEquality();
+    while (current().kind == TokKind::AmpAmp) {
+      const SourceLoc loc = current().loc;
+      advance();
+      ExprPtr rhs = parseEquality();
+      lhs =
+          makeBinary(BinaryOp::LogicalAnd, std::move(lhs), std::move(rhs), loc);
+    }
+    return lhs;
+  }
+
+  ExprPtr parseEquality() {
+    ExprPtr lhs = parseRelational();
+    while (current().kind == TokKind::EqEq ||
+           current().kind == TokKind::BangEq) {
+      const BinaryOp op =
+          current().kind == TokKind::EqEq ? BinaryOp::Eq : BinaryOp::Ne;
+      const SourceLoc loc = current().loc;
+      advance();
+      ExprPtr rhs = parseRelational();
+      lhs = makeBinary(op, std::move(lhs), std::move(rhs), loc);
+    }
+    return lhs;
+  }
+
+  ExprPtr parseRelational() {
+    ExprPtr lhs = parseAdditive();
+    while (true) {
+      const TokKind k = current().kind;
+      BinaryOp op = BinaryOp::Eq;
+      if (k == TokKind::Lt) {
+        op = BinaryOp::Lt;
+      } else if (k == TokKind::Le) {
+        op = BinaryOp::Le;
+      } else if (k == TokKind::Gt) {
+        op = BinaryOp::Gt;
+      } else if (k == TokKind::Ge) {
+        op = BinaryOp::Ge;
+      } else {
+        return lhs;
+      }
+      const SourceLoc loc = current().loc;
+      advance();
+      ExprPtr rhs = parseAdditive();
+      lhs = makeBinary(op, std::move(lhs), std::move(rhs), loc);
+    }
+  }
+
+  ExprPtr parseAdditive() {
+    ExprPtr lhs = parseMultiplicative();
+    while (current().kind == TokKind::Plus ||
+           current().kind == TokKind::Minus) {
+      const BinaryOp op =
+          current().kind == TokKind::Plus ? BinaryOp::Add : BinaryOp::Sub;
+      const SourceLoc loc = current().loc;
+      advance();
+      ExprPtr rhs = parseMultiplicative();
+      lhs = makeBinary(op, std::move(lhs), std::move(rhs), loc);
+    }
+    return lhs;
+  }
+
+  ExprPtr parseMultiplicative() {
+    ExprPtr lhs = parseUnary();
+    while (true) {
+      const TokKind k = current().kind;
+      BinaryOp op = BinaryOp::Mul;
+      if (k == TokKind::Star) {
+        op = BinaryOp::Mul;
+      } else if (k == TokKind::Slash) {
+        op = BinaryOp::Div;
+      } else if (k == TokKind::Percent) {
+        op = BinaryOp::Mod;
+      } else {
+        return lhs;
+      }
+      const SourceLoc loc = current().loc;
+      advance();
+      ExprPtr rhs = parseUnary();
+      lhs = makeBinary(op, std::move(lhs), std::move(rhs), loc);
+    }
+  }
+
+  ExprPtr parseUnary() {
+    if (current().kind == TokKind::Bang) {
+      const SourceLoc loc = current().loc;
+      advance();
+      return makeUnary(UnaryOp::Not, parseUnary(), loc);
+    }
+    if (current().kind == TokKind::Minus) {
+      const SourceLoc loc = current().loc;
+      advance();
+      return makeUnary(UnaryOp::Neg, parseUnary(), loc);
+    }
+    return parsePrimary();
+  }
+
+  ExprPtr parsePrimary() {
+    const Token tok = current();
+    if (tok.kind == TokKind::Ident) {
+      advance();
+      return makeExpr(Identifier{tok.text}, tok.loc);
+    }
+    if (tok.kind == TokKind::IntLit) {
+      advance();
+      std::int64_t value = 0;
+      try {
+        value = std::stoll(tok.text);
+      } catch (...) {
+        reportAt("integer literal out of range: " + tok.text, tok.loc);
+      }
+      return makeExpr(IntLiteral{value}, tok.loc);
+    }
+    if (tok.kind == TokKind::KwResult) {
+      advance();
+      return makeExpr(ResultExpr{}, tok.loc);
+    }
+    if (tok.kind == TokKind::LParen) {
+      advance();
+      ExprPtr inner = parsePredicate();
+      expect(TokKind::RParen, "expected ')' to close expression");
+      return inner;
+    }
+    reportAt("expected expression, got '" + tok.text + "'", tok.loc);
+    advance();
+    return makeExpr(IntLiteral{0}, tok.loc); // error recovery stub
+  }
+
+  bool expect(TokKind kind, const std::string &message) {
+    if (current().kind == kind) {
+      advance();
+      return true;
+    }
+    reportAt(message, current().loc);
+    return false;
+  }
+
+  void syncToNextClause() {
+    while (current().kind != TokKind::Eof) {
+      if (current().kind == TokKind::Semi) {
+        advance();
+        return;
+      }
+      advance();
+    }
+  }
+
+  void reportAt(std::string message, SourceLoc loc) {
+    errors_.push_back({std::move(message), loc});
+  }
+
+  [[nodiscard]] const Token &current() const { return tokens_[cursor_]; }
+
+  void advance() {
+    if (tokens_[cursor_].kind != TokKind::Eof) {
+      ++cursor_;
+    }
+  }
+
+  static ExprPtr makeBinary(BinaryOp op, ExprPtr lhs, ExprPtr rhs,
+                            SourceLoc loc) {
+    auto expr = std::make_unique<Expr>();
+    expr->node = BinaryExpr{op, std::move(lhs), std::move(rhs)};
+    expr->loc = loc;
+    return expr;
+  }
+
+  static ExprPtr makeUnary(UnaryOp op, ExprPtr operand, SourceLoc loc) {
+    auto expr = std::make_unique<Expr>();
+    expr->node = UnaryExpr{op, std::move(operand)};
+    expr->loc = loc;
+    return expr;
+  }
+
+  template <typename T> static ExprPtr makeExpr(T node, SourceLoc loc) {
+    auto expr = std::make_unique<Expr>();
+    expr->node = std::move(node);
+    expr->loc = loc;
+    return expr;
+  }
+
+  std::vector<Token> tokens_;
+  std::vector<ParseError> &errors_;
+  std::size_t cursor_ = 0;
+};
+// NOLINTEND(misc-no-recursion)
+
+//===----------------------------------------------------------------------===//
+// Pretty-printing
+//===----------------------------------------------------------------------===//
+
+const char *binaryOpSpelling(BinaryOp op) {
+  switch (op) {
+  case BinaryOp::Eq:
+    return "==";
+  case BinaryOp::Ne:
+    return "!=";
+  case BinaryOp::Lt:
+    return "<";
+  case BinaryOp::Le:
+    return "<=";
+  case BinaryOp::Gt:
+    return ">";
+  case BinaryOp::Ge:
+    return ">=";
+  case BinaryOp::Add:
+    return "+";
+  case BinaryOp::Sub:
+    return "-";
+  case BinaryOp::Mul:
+    return "*";
+  case BinaryOp::Div:
+    return "/";
+  case BinaryOp::Mod:
+    return "%";
+  case BinaryOp::LogicalAnd:
+    return "&&";
+  case BinaryOp::LogicalOr:
+    return "||";
+  }
+  return "?";
+}
+
+const char *unaryOpSpelling(UnaryOp op) {
+  switch (op) {
+  case UnaryOp::Neg:
+    return "-";
+  case UnaryOp::Not:
+    return "!";
+  }
+  return "?";
+}
+
+// Expression printing recurses through nested Binary / Unary nodes.
+// NOLINTBEGIN(misc-no-recursion)
+void printExpr(std::ostringstream &out, const Expr &expr) {
+  std::visit(
+      [&out](const auto &node) {
+        using T = std::decay_t<decltype(node)>;
+        if constexpr (std::is_same_v<T, Identifier>) {
+          out << node.name;
+        } else if constexpr (std::is_same_v<T, IntLiteral>) {
+          out << node.value;
+        } else if constexpr (std::is_same_v<T, ResultExpr>) {
+          out << "\\result";
+        } else if constexpr (std::is_same_v<T, BinaryExpr>) {
+          out << "(" << binaryOpSpelling(node.op) << " ";
+          printExpr(out, *node.lhs);
+          out << " ";
+          printExpr(out, *node.rhs);
+          out << ")";
+        } else if constexpr (std::is_same_v<T, UnaryExpr>) {
+          out << "(" << unaryOpSpelling(node.op) << " ";
+          printExpr(out, *node.operand);
+          out << ")";
+        }
+      },
+      expr.node);
+}
+// NOLINTEND(misc-no-recursion)
+
+const char *clauseKindSpelling(ClauseKind kind) {
+  switch (kind) {
+  case ClauseKind::Requires:
+    return "requires";
+  case ClauseKind::Ensures:
+    return "ensures";
+  case ClauseKind::AssignsNothing:
+    return "assigns \\nothing";
+  }
+  return "?";
+}
+
+} // namespace
+
+//===----------------------------------------------------------------------===//
+// Public API
+//===----------------------------------------------------------------------===//
+
+ParseResult parseContract(std::string_view input) {
+  ParseResult result;
+  Lexer lexer(input);
+  auto tokens = lexer.tokenize(result.errors);
+  Parser parser(std::move(tokens), result.errors);
+  result.clauses = parser.parseClauses();
+  return result;
+}
+
+std::string toString(const Expr &expr) {
+  std::ostringstream out;
+  printExpr(out, expr);
+  return out.str();
+}
+
+std::string toString(const Clause &clause) {
+  std::ostringstream out;
+  out << "[" << clause.index << "] " << clauseKindSpelling(clause.kind);
+  if (clause.predicate) {
+    out << " ";
+    printExpr(out, *clause.predicate);
+  }
+  return out.str();
+}
+
+} // namespace arcanum::parser

--- a/arcanum/parser/ECSLParser.h
+++ b/arcanum/parser/ECSLParser.h
@@ -1,0 +1,137 @@
+/// \file
+/// ECSL contract comment parser: tokenizes and parses the body of a
+/// `/*@ requires ... ensures ... */` annotation into a structured
+/// clause tree.
+
+#ifndef PARSER_ECSLPARSER_H
+#define PARSER_ECSLPARSER_H
+
+#include <cstdint>
+#include <memory>
+#include <string>
+#include <string_view>
+#include <variant>
+#include <vector>
+
+namespace arcanum::parser {
+
+/// 1-based line and column in the contract comment body.
+struct SourceLoc {
+  unsigned line = 1; ///< 1-based line number.
+  unsigned col = 1;  ///< 1-based column number.
+};
+
+/// Binary operators recognized by the ECSL contract parser.
+enum class BinaryOp : std::uint8_t {
+  // Comparison
+  Eq,
+  Ne,
+  Lt,
+  Le,
+  Gt,
+  Ge,
+  // Arithmetic
+  Add,
+  Sub,
+  Mul,
+  Div,
+  Mod,
+  // Logical
+  LogicalAnd,
+  LogicalOr,
+};
+
+/// Unary operators recognized by the ECSL contract parser.
+enum class UnaryOp : std::uint8_t {
+  Neg, ///< arithmetic negation `-x`
+  Not, ///< logical negation `!p`
+};
+
+struct Expr;
+/// Owning handle to an expression node.
+using ExprPtr = std::unique_ptr<Expr>;
+
+/// A bare identifier expression.
+struct Identifier {
+  std::string name; ///< Identifier spelling.
+};
+
+/// A decimal integer literal.
+struct IntLiteral {
+  std::int64_t value; ///< Decoded literal value.
+};
+
+/// The special `\\result` identifier referring to an ensures-clause
+/// function return value.
+struct ResultExpr {};
+
+/// A binary expression node.
+struct BinaryExpr {
+  BinaryOp op; ///< Operator.
+  ExprPtr lhs; ///< Left operand.
+  ExprPtr rhs; ///< Right operand.
+};
+
+/// A unary expression node.
+struct UnaryExpr {
+  UnaryOp op;      ///< Operator.
+  ExprPtr operand; ///< Single operand.
+};
+
+/// An expression tree node with source location.
+struct Expr {
+  /// Concrete node payload.
+  std::variant<Identifier, IntLiteral, ResultExpr, BinaryExpr, UnaryExpr> node;
+  SourceLoc loc; ///< Source location of the expression's head token.
+};
+
+/// Kind of a parsed top-level contract clause.
+enum class ClauseKind : std::uint8_t {
+  Requires,
+  Ensures,
+  AssignsNothing,
+};
+
+/// One parsed contract clause.
+struct Clause {
+  ClauseKind kind; ///< Kind of this clause.
+  /// `nullptr` for `AssignsNothing`, otherwise the parsed predicate.
+  ExprPtr predicate;
+  SourceLoc loc;      ///< Source location of the clause keyword.
+  unsigned index = 0; ///< 0-based index within the parsed comment,
+                      ///< used by the caller to synthesize
+                      ///< `ecsl.property_id` attributes.
+};
+
+/// A single parser or lexer diagnostic.
+struct ParseError {
+  std::string message; ///< Human-readable message.
+  SourceLoc loc;       ///< Source location where the error was raised.
+};
+
+/// Result of parsing a contract body: parsed clauses plus any errors
+/// encountered during lexing/parsing. Partial progress is preserved
+/// in `clauses` even when `errors` is non-empty.
+struct ParseResult {
+  std::vector<Clause> clauses;    ///< Successfully parsed clauses.
+  std::vector<ParseError> errors; ///< Lex/parse diagnostics.
+
+  /// Returns `true` if parsing produced no errors.
+  [[nodiscard]] bool ok() const { return errors.empty(); }
+};
+
+/// Parse the contents of an ECSL contract comment body (i.e. the text
+/// between `/*@` and `*/`, without those delimiters). The body may
+/// contain one or more clauses separated by `;`.
+ParseResult parseContract(std::string_view input);
+
+/// Pretty-print an expression as an S-expression for tests /
+/// diagnostics.
+std::string toString(const Expr &expr);
+
+/// Pretty-print a clause.
+std::string toString(const Clause &clause);
+
+} // namespace arcanum::parser
+
+#endif // PARSER_ECSLPARSER_H

--- a/arcanum/test/CMakeLists.txt
+++ b/arcanum/test/CMakeLists.txt
@@ -2,6 +2,7 @@
 
 # --- Unit tests (C++ executables, run via CTest) ---
 add_subdirectory(ecsl)
+add_subdirectory(parser)
 add_subdirectory(testgen)
 add_subdirectory(tools)
 

--- a/arcanum/test/parser/CMakeLists.txt
+++ b/arcanum/test/parser/CMakeLists.txt
@@ -1,0 +1,14 @@
+# test/parser/ - Parser unit tests
+
+add_executable(arcanum-test-ecsl-parser
+  ECSLParserTest.cpp
+)
+
+target_link_libraries(arcanum-test-ecsl-parser
+  PRIVATE
+  ArcanumParser
+)
+
+add_test(NAME ecsl-parser
+  COMMAND arcanum-test-ecsl-parser
+)

--- a/arcanum/test/parser/ECSLParserTest.cpp
+++ b/arcanum/test/parser/ECSLParserTest.cpp
@@ -1,0 +1,75 @@
+// Unit test for arcanum::parser::parseContract: parses a handful of
+// representative ECSL contract bodies and checks the pretty-printed
+// AST against expected strings.
+
+#include "parser/ECSLParser.h"
+
+#include <array>
+#include <iostream>
+#include <string>
+#include <string_view>
+
+namespace {
+
+struct Case {
+  std::string_view name;
+  std::string_view input;
+  std::string_view expected;
+};
+
+bool run(const Case &c) {
+  const arcanum::parser::ParseResult result =
+      arcanum::parser::parseContract(c.input);
+  std::string actual;
+  for (const auto &err : result.errors) {
+    actual += "error@" + std::to_string(err.loc.line) + ":" +
+              std::to_string(err.loc.col) + ": " + err.message + "\n";
+  }
+  for (const auto &clause : result.clauses) {
+    actual += toString(clause);
+    actual += "\n";
+  }
+  if (actual != std::string(c.expected)) {
+    std::cerr << "FAIL: " << c.name << "\n"
+              << "  input:    " << c.input << "\n"
+              << "  expected: |" << c.expected << "|\n"
+              << "  actual:   |" << actual << "|\n";
+    return false;
+  }
+  return true;
+}
+
+} // namespace
+
+int main() {
+  const std::array<Case, 9> cases{{
+      {"single_requires", "requires x >= 0;", "[0] requires (>= x 0)\n"},
+      {"single_ensures_with_result", "ensures \\result >= 0;",
+       "[0] ensures (>= \\result 0)\n"},
+      {"assigns_nothing", "assigns \\nothing;", "[0] assigns \\nothing\n"},
+      {"multiple_clauses",
+       "requires x > 0; requires y > 0; ensures \\result == x + y;",
+       "[0] requires (> x 0)\n"
+       "[1] requires (> y 0)\n"
+       "[2] ensures (== \\result (+ x y))\n"},
+      {"precedence", "requires a + b * c <= d;",
+       "[0] requires (<= (+ a (* b c)) d)\n"},
+      {"logical_connectives", "requires x > 0 && (y > 0 || z == 0);",
+       "[0] requires (&& (> x 0) (|| (> y 0) (== z 0)))\n"},
+      {"unary_not_and_neg", "requires !(x == 0) && y == -1;",
+       "[0] requires (&& (! (== x 0)) (== y (- 1)))\n"},
+      {"error_missing_semicolon", "requires x > 0",
+       "error@1:15: expected ';' at end of clause\n"},
+      {"error_bad_token", "requires x & y;",
+       "error@1:12: unexpected '&'\n"
+       "error@1:14: expected ';' at end of clause\n"},
+  }};
+
+  bool allPassed = true;
+  for (const auto &c : cases) {
+    if (!run(c)) {
+      allPassed = false;
+    }
+  }
+  return allPassed ? 0 : 1;
+}


### PR DESCRIPTION
## Summary
Adds `arcanum::parser::parseContract` — a recursive-descent parser for the ECSL contract-comment grammar (issue #9).

**Grammar:**
```
clause    := ('requires' | 'ensures') predicate ';'
           | 'assigns' '\nothing' ';'
predicate := logical_or
logical_or     := logical_and ('||' logical_and)*
logical_and    := equality    ('&&' equality)*
equality       := relational  (('==' | '!=') relational)*
relational     := additive    (('<' | '<=' | '>' | '>=') additive)*
additive       := multiplicative (('+' | '-') multiplicative)*
multiplicative := unary       (('*' | '/' | '%') unary)*
unary          := ('-' | '!') unary | primary
primary        := identifier | int-literal | '\result' | '(' predicate ')'
```

**Output:** `std::variant`-based AST (`Identifier` / `IntLiteral` / `ResultExpr` / `BinaryExpr` / `UnaryExpr`) with `SourceLoc` on every node and a 0-based clause index ready for `ecsl.property_id` synthesis.

**Error recovery:** skips to the next `;` after a diagnostic so one bad clause doesn't mask subsequent ones.

**Tests:** `arcanum-test-ecsl-parser` covers 9 cases (atoms, precedence, logical connectives, unary ops, two error paths).

Closes #9.

## Out of scope (covered by issue #10)
- Clang AST integration (`RawComment` extraction).
- Lowering the parsed AST to MLIR ops in the `ecsl` dialect.

## Warning-flag changes
`cmake/Warnings.cmake`:
- Drops `-Wswitch-default` (contradicts `-Wcovered-switch-default`, which is the more useful one).
- Drops `-Wpadded` (noisy; LLVM disables it project-wide).

`.clang-tidy`:
- Allows trailing-underscore private members (`tokens_`, `cursor_`).
- Exempts public-only data structs from the private-members rule.

## Test plan
- [x] 5/5 CTest targets pass (ecsl-register, ecsl-contract-ops-roundtrip, ecsl-parser, testgen-register, arcanum-opt-roundtrip).
- [x] clang-format, clang-tidy, header-guards, codespell, doxygen all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)