### PR TITLE
Implement ECSL contract lexer

### DIFF
--- a/arcanum/parser/ECSLParser.cpp
+++ b/arcanum/parser/ECSLParser.cpp
@@ -1,15 +1,278 @@
 /// \file
-/// Stub implementations for the ECSL contract parser public API.
-/// The lexer and parser are added in subsequent commits.
+/// ECSL contract comment parser implementation.
+/// This file contains the lexer; the recursive-descent parser and
+/// pretty-printer are added in subsequent commits.
 
 #include "parser/ECSLParser.h"
 
+#include <cctype>
+#include <cstddef>
+#include <cstdint>
 #include <string>
 #include <string_view>
+#include <utility>
+#include <vector>
 
 namespace arcanum::parser {
 
-ParseResult parseContract(std::string_view /*input*/) { return {}; }
+namespace {
+
+//===----------------------------------------------------------------------===//
+// Tokens
+//===----------------------------------------------------------------------===//
+
+enum class TokKind : std::uint8_t {
+  // Keywords
+  KwRequires,
+  KwEnsures,
+  KwAssigns,
+  KwResult,
+  KwNothing,
+  // Atoms
+  Ident,
+  IntLit,
+  // Punctuation
+  LParen,
+  RParen,
+  Semi,
+  // Operators
+  EqEq,
+  BangEq,
+  Lt,
+  Le,
+  Gt,
+  Ge,
+  Plus,
+  Minus,
+  Star,
+  Slash,
+  Percent,
+  Bang,
+  AmpAmp,
+  PipePipe,
+  // Control
+  Eof,
+  Error,
+};
+
+struct Token {
+  TokKind kind = TokKind::Eof;
+  std::string text;
+  SourceLoc loc;
+};
+
+class Lexer {
+public:
+  explicit Lexer(std::string_view src) : input(src) {}
+
+  std::vector<Token> tokenize(std::vector<ParseError>& errors) {
+    std::vector<Token> out;
+    while (true) {
+      skipWhitespace();
+      Token tok = lexOne();
+      if (tok.kind == TokKind::Error) {
+        errors.push_back({std::move(tok.text), tok.loc});
+        continue;
+      }
+      const bool done = tok.kind == TokKind::Eof;
+      out.push_back(std::move(tok));
+      if (done) {
+        break;
+      }
+    }
+    return out;
+  }
+
+private:
+  Token lexOne() {
+    if (atEnd()) {
+      return makeAt(TokKind::Eof, "", loc);
+    }
+    const SourceLoc start = loc;
+    const char c = peek();
+
+    if ((std::isalpha(static_cast<unsigned char>(c)) != 0) || c == '_') {
+      return lexIdentifier(start);
+    }
+    if (std::isdigit(static_cast<unsigned char>(c)) != 0) {
+      return lexInteger(start);
+    }
+    if (c == '\\') {
+      return lexBackslashKeyword(start);
+    }
+    return lexOperatorOrPunct(start);
+  }
+
+  Token lexIdentifier(SourceLoc start) {
+    std::string text;
+    while (!atEnd()) {
+      const char c = peek();
+      const bool isWord =
+          (std::isalnum(static_cast<unsigned char>(c)) != 0) || c == '_';
+      if (!isWord) {
+        break;
+      }
+      text.push_back(c);
+      advance();
+    }
+    if (text == "requires") {
+      return makeAt(TokKind::KwRequires, std::move(text), start);
+    }
+    if (text == "ensures") {
+      return makeAt(TokKind::KwEnsures, std::move(text), start);
+    }
+    if (text == "assigns") {
+      return makeAt(TokKind::KwAssigns, std::move(text), start);
+    }
+    return makeAt(TokKind::Ident, std::move(text), start);
+  }
+
+  Token lexInteger(SourceLoc start) {
+    std::string text;
+    while (!atEnd() &&
+           (std::isdigit(static_cast<unsigned char>(peek())) != 0)) {
+      text.push_back(peek());
+      advance();
+    }
+    return makeAt(TokKind::IntLit, std::move(text), start);
+  }
+
+  Token lexBackslashKeyword(SourceLoc start) {
+    advance(); // consume '\'
+    std::string text;
+    while (!atEnd()) {
+      const char c = peek();
+      const bool isWord =
+          (std::isalpha(static_cast<unsigned char>(c)) != 0) || c == '_';
+      if (!isWord) {
+        break;
+      }
+      text.push_back(c);
+      advance();
+    }
+    if (text == "result") {
+      return makeAt(TokKind::KwResult, "\\result", start);
+    }
+    if (text == "nothing") {
+      return makeAt(TokKind::KwNothing, "\\nothing", start);
+    }
+    return makeAt(TokKind::Error, "unknown backslash keyword: \\" + text,
+                  start);
+  }
+
+  Token lexOperatorOrPunct(SourceLoc start) {
+    const char c = peek();
+    advance();
+    switch (c) {
+    case '(':
+      return makeAt(TokKind::LParen, "(", start);
+    case ')':
+      return makeAt(TokKind::RParen, ")", start);
+    case ';':
+      return makeAt(TokKind::Semi, ";", start);
+    case '+':
+      return makeAt(TokKind::Plus, "+", start);
+    case '-':
+      return makeAt(TokKind::Minus, "-", start);
+    case '*':
+      return makeAt(TokKind::Star, "*", start);
+    case '/':
+      return makeAt(TokKind::Slash, "/", start);
+    case '%':
+      return makeAt(TokKind::Percent, "%", start);
+    case '=':
+      if (!atEnd() && peek() == '=') {
+        advance();
+        return makeAt(TokKind::EqEq, "==", start);
+      }
+      return makeAt(TokKind::Error, "unexpected '='", start);
+    case '!':
+      if (!atEnd() && peek() == '=') {
+        advance();
+        return makeAt(TokKind::BangEq, "!=", start);
+      }
+      return makeAt(TokKind::Bang, "!", start);
+    case '<':
+      if (!atEnd() && peek() == '=') {
+        advance();
+        return makeAt(TokKind::Le, "<=", start);
+      }
+      return makeAt(TokKind::Lt, "<", start);
+    case '>':
+      if (!atEnd() && peek() == '=') {
+        advance();
+        return makeAt(TokKind::Ge, ">=", start);
+      }
+      return makeAt(TokKind::Gt, ">", start);
+    case '&':
+      if (!atEnd() && peek() == '&') {
+        advance();
+        return makeAt(TokKind::AmpAmp, "&&", start);
+      }
+      return makeAt(TokKind::Error, "unexpected '&'", start);
+    case '|':
+      if (!atEnd() && peek() == '|') {
+        advance();
+        return makeAt(TokKind::PipePipe, "||", start);
+      }
+      return makeAt(TokKind::Error, "unexpected '|'", start);
+    default:
+      return makeAt(TokKind::Error,
+                    std::string("unexpected character: '") + c + "'", start);
+    }
+  }
+
+  void skipWhitespace() {
+    while (!atEnd()) {
+      const char c = peek();
+      if (c != ' ' && c != '\t' && c != '\r' && c != '\n') {
+        break;
+      }
+      advance();
+    }
+  }
+
+  [[nodiscard]] bool atEnd() const { return pos >= input.size(); }
+  [[nodiscard]] char peek() const { return input[pos]; }
+
+  void advance() {
+    if (atEnd()) {
+      return;
+    }
+    if (input[pos] == '\n') {
+      ++loc.line;
+      loc.col = 1;
+    } else {
+      ++loc.col;
+    }
+    ++pos;
+  }
+
+  static Token makeAt(TokKind kind, std::string text, SourceLoc loc) {
+    Token tok;
+    tok.kind = kind;
+    tok.text = std::move(text);
+    tok.loc = loc;
+    return tok;
+  }
+
+  std::string_view input;
+  std::size_t pos = 0;
+  SourceLoc loc;
+};
+
+} // namespace
+
+//===----------------------------------------------------------------------===//
+// Public API
+//===----------------------------------------------------------------------===//
+
+ParseResult parseContract(std::string_view input) {
+  ParseResult result;
+  Lexer lexer(input);
+  lexer.tokenize(result.errors);
+  return result;
+}
 
 std::string toString(const Expr& /*expr*/) { return {}; }
 

--- a/arcanum/parser/ECSLParser.cpp
+++ b/arcanum/parser/ECSLParser.cpp
@@ -86,7 +86,7 @@ public:
 private:
   Token lexOne() {
     if (atEnd()) {
-      return makeAt(TokKind::Eof, "", loc);
+      return makeToken(TokKind::Eof, "", loc);
     }
     const SourceLoc start = loc;
     const char c = peek();
@@ -116,15 +116,15 @@ private:
       advance();
     }
     if (text == "requires") {
-      return makeAt(TokKind::KwRequires, std::move(text), start);
+      return makeToken(TokKind::KwRequires, std::move(text), start);
     }
     if (text == "ensures") {
-      return makeAt(TokKind::KwEnsures, std::move(text), start);
+      return makeToken(TokKind::KwEnsures, std::move(text), start);
     }
     if (text == "assigns") {
-      return makeAt(TokKind::KwAssigns, std::move(text), start);
+      return makeToken(TokKind::KwAssigns, std::move(text), start);
     }
-    return makeAt(TokKind::Ident, std::move(text), start);
+    return makeToken(TokKind::Ident, std::move(text), start);
   }
 
   Token lexInteger(SourceLoc start) {
@@ -134,7 +134,7 @@ private:
       text.push_back(peek());
       advance();
     }
-    return makeAt(TokKind::IntLit, std::move(text), start);
+    return makeToken(TokKind::IntLit, std::move(text), start);
   }
 
   Token lexBackslashKeyword(SourceLoc start) {
@@ -151,12 +151,12 @@ private:
       advance();
     }
     if (text == "result") {
-      return makeAt(TokKind::KwResult, "\\result", start);
+      return makeToken(TokKind::KwResult, "\\result", start);
     }
     if (text == "nothing") {
-      return makeAt(TokKind::KwNothing, "\\nothing", start);
+      return makeToken(TokKind::KwNothing, "\\nothing", start);
     }
-    return makeAt(TokKind::Error, "unknown backslash keyword: \\" + text,
+    return makeToken(TokKind::Error, "unknown backslash keyword: \\" + text,
                   start);
   }
 
@@ -165,59 +165,59 @@ private:
     advance();
     switch (c) {
     case '(':
-      return makeAt(TokKind::LParen, "(", start);
+      return makeToken(TokKind::LParen, "(", start);
     case ')':
-      return makeAt(TokKind::RParen, ")", start);
+      return makeToken(TokKind::RParen, ")", start);
     case ';':
-      return makeAt(TokKind::Semi, ";", start);
+      return makeToken(TokKind::Semi, ";", start);
     case '+':
-      return makeAt(TokKind::Plus, "+", start);
+      return makeToken(TokKind::Plus, "+", start);
     case '-':
-      return makeAt(TokKind::Minus, "-", start);
+      return makeToken(TokKind::Minus, "-", start);
     case '*':
-      return makeAt(TokKind::Star, "*", start);
+      return makeToken(TokKind::Star, "*", start);
     case '/':
-      return makeAt(TokKind::Slash, "/", start);
+      return makeToken(TokKind::Slash, "/", start);
     case '%':
-      return makeAt(TokKind::Percent, "%", start);
+      return makeToken(TokKind::Percent, "%", start);
     case '=':
       if (!atEnd() && peek() == '=') {
         advance();
-        return makeAt(TokKind::EqEq, "==", start);
+        return makeToken(TokKind::EqEq, "==", start);
       }
-      return makeAt(TokKind::Error, "unexpected '='", start);
+      return makeToken(TokKind::Error, "unexpected '='", start);
     case '!':
       if (!atEnd() && peek() == '=') {
         advance();
-        return makeAt(TokKind::BangEq, "!=", start);
+        return makeToken(TokKind::BangEq, "!=", start);
       }
-      return makeAt(TokKind::Bang, "!", start);
+      return makeToken(TokKind::Bang, "!", start);
     case '<':
       if (!atEnd() && peek() == '=') {
         advance();
-        return makeAt(TokKind::Le, "<=", start);
+        return makeToken(TokKind::Le, "<=", start);
       }
-      return makeAt(TokKind::Lt, "<", start);
+      return makeToken(TokKind::Lt, "<", start);
     case '>':
       if (!atEnd() && peek() == '=') {
         advance();
-        return makeAt(TokKind::Ge, ">=", start);
+        return makeToken(TokKind::Ge, ">=", start);
       }
-      return makeAt(TokKind::Gt, ">", start);
+      return makeToken(TokKind::Gt, ">", start);
     case '&':
       if (!atEnd() && peek() == '&') {
         advance();
-        return makeAt(TokKind::AmpAmp, "&&", start);
+        return makeToken(TokKind::AmpAmp, "&&", start);
       }
-      return makeAt(TokKind::Error, "unexpected '&'", start);
+      return makeToken(TokKind::Error, "unexpected '&'", start);
     case '|':
       if (!atEnd() && peek() == '|') {
         advance();
-        return makeAt(TokKind::PipePipe, "||", start);
+        return makeToken(TokKind::PipePipe, "||", start);
       }
-      return makeAt(TokKind::Error, "unexpected '|'", start);
+      return makeToken(TokKind::Error, "unexpected '|'", start);
     default:
-      return makeAt(TokKind::Error,
+      return makeToken(TokKind::Error,
                     std::string("unexpected character: '") + c + "'", start);
     }
   }
@@ -248,7 +248,7 @@ private:
     ++pos;
   }
 
-  static Token makeAt(TokKind kind, std::string text, SourceLoc loc) {
+  [[nodiscard]] static Token makeToken(TokKind kind, std::string text, SourceLoc loc) {
     Token tok;
     tok.kind = kind;
     tok.text = std::move(text);
@@ -270,7 +270,9 @@ private:
 ParseResult parseContract(std::string_view input) {
   ParseResult result;
   Lexer lexer(input);
-  lexer.tokenize(result.errors);
+  const auto tokens = lexer.tokenize(result.errors);
+  std::ignore = tokens;
+  //TODO: implement parsing here
   return result;
 }
 

--- a/arcanum/parser/ECSLParser.cpp
+++ b/arcanum/parser/ECSLParser.cpp
@@ -86,7 +86,7 @@ public:
 private:
   Token lexOne() {
     if (atEnd()) {
-      return makeToken(TokKind::Eof, "", loc);
+      return Token{TokKind::Eof, "", loc};
     }
     const SourceLoc start = loc;
     const char c = peek();
@@ -116,15 +116,15 @@ private:
       advance();
     }
     if (text == "requires") {
-      return makeToken(TokKind::KwRequires, std::move(text), start);
+      return Token{TokKind::KwRequires, std::move(text), start};
     }
     if (text == "ensures") {
-      return makeToken(TokKind::KwEnsures, std::move(text), start);
+      return Token{TokKind::KwEnsures, std::move(text), start};
     }
     if (text == "assigns") {
-      return makeToken(TokKind::KwAssigns, std::move(text), start);
+      return Token{TokKind::KwAssigns, std::move(text), start};
     }
-    return makeToken(TokKind::Ident, std::move(text), start);
+    return Token{TokKind::Ident, std::move(text), start};
   }
 
   Token lexInteger(SourceLoc start) {
@@ -134,7 +134,7 @@ private:
       text.push_back(peek());
       advance();
     }
-    return makeToken(TokKind::IntLit, std::move(text), start);
+    return Token{TokKind::IntLit, std::move(text), start};
   }
 
   Token lexBackslashKeyword(SourceLoc start) {
@@ -151,13 +151,12 @@ private:
       advance();
     }
     if (text == "result") {
-      return makeToken(TokKind::KwResult, "\\result", start);
+      return Token{TokKind::KwResult, "\\result", start};
     }
     if (text == "nothing") {
-      return makeToken(TokKind::KwNothing, "\\nothing", start);
+      return Token{TokKind::KwNothing, "\\nothing", start};
     }
-    return makeToken(TokKind::Error, "unknown backslash keyword: \\" + text,
-                  start);
+    return Token{TokKind::Error, "unknown backslash keyword: \\" + text, start};
   }
 
   Token lexOperatorOrPunct(SourceLoc start) {
@@ -165,67 +164,67 @@ private:
     advance();
     switch (c) {
     case '(':
-      return makeToken(TokKind::LParen, "(", start);
+      return Token{TokKind::LParen, "(", start};
     case ')':
-      return makeToken(TokKind::RParen, ")", start);
+      return Token{TokKind::RParen, ")", start};
     case ';':
-      return makeToken(TokKind::Semi, ";", start);
+      return Token{TokKind::Semi, ";", start};
     case '+':
-      return makeToken(TokKind::Plus, "+", start);
+      return Token{TokKind::Plus, "+", start};
     case '-':
-      return makeToken(TokKind::Minus, "-", start);
+      return Token{TokKind::Minus, "-", start};
     case '*':
-      return makeToken(TokKind::Star, "*", start);
+      return Token{TokKind::Star, "*", start};
     case '/':
-      return makeToken(TokKind::Slash, "/", start);
+      return Token{TokKind::Slash, "/", start};
     case '%':
-      return makeToken(TokKind::Percent, "%", start);
+      return Token{TokKind::Percent, "%", start};
     case '=':
       if (!atEnd() && peek() == '=') {
         advance();
-        return makeToken(TokKind::EqEq, "==", start);
+        return Token{TokKind::EqEq, "==", start};
       }
-      return makeToken(TokKind::Error, "unexpected '='", start);
+      return Token{TokKind::Error, "unexpected '='", start};
     case '!':
       if (!atEnd() && peek() == '=') {
         advance();
-        return makeToken(TokKind::BangEq, "!=", start);
+        return Token{TokKind::BangEq, "!=", start};
       }
-      return makeToken(TokKind::Bang, "!", start);
+      return Token{TokKind::Bang, "!", start};
     case '<':
       if (!atEnd() && peek() == '=') {
         advance();
-        return makeToken(TokKind::Le, "<=", start);
+        return Token{TokKind::Le, "<=", start};
       }
-      return makeToken(TokKind::Lt, "<", start);
+      return Token{TokKind::Lt, "<", start};
     case '>':
       if (!atEnd() && peek() == '=') {
         advance();
-        return makeToken(TokKind::Ge, ">=", start);
+        return Token{TokKind::Ge, ">=", start};
       }
-      return makeToken(TokKind::Gt, ">", start);
+      return Token{TokKind::Gt, ">", start};
     case '&':
       if (!atEnd() && peek() == '&') {
         advance();
-        return makeToken(TokKind::AmpAmp, "&&", start);
+        return Token{TokKind::AmpAmp, "&&", start};
       }
-      return makeToken(TokKind::Error, "unexpected '&'", start);
+      return Token{TokKind::Error, "unexpected '&'", start};
     case '|':
       if (!atEnd() && peek() == '|') {
         advance();
-        return makeToken(TokKind::PipePipe, "||", start);
+        return Token{TokKind::PipePipe, "||", start};
       }
-      return makeToken(TokKind::Error, "unexpected '|'", start);
+      return Token{TokKind::Error, "unexpected '|'", start};
     default:
-      return makeToken(TokKind::Error,
-                    std::string("unexpected character: '") + c + "'", start);
+      return Token{TokKind::Error,
+                   std::string("unexpected character: '") + c + "'", start};
     }
   }
 
   void skipWhitespace() {
     while (!atEnd()) {
       const char c = peek();
-      if (c != ' ' && c != '\t' && c != '\r' && c != '\n') {
+      if (!isWhitespace(c)) {
         break;
       }
       advance();
@@ -239,7 +238,7 @@ private:
     if (atEnd()) {
       return;
     }
-    if (input[pos] == '\n') {
+    if (isNewline(input[pos])) {
       ++loc.line;
       loc.col = 1;
     } else {
@@ -248,12 +247,12 @@ private:
     ++pos;
   }
 
-  [[nodiscard]] static Token makeToken(TokKind kind, std::string text, SourceLoc loc) {
-    Token tok;
-    tok.kind = kind;
-    tok.text = std::move(text);
-    tok.loc = loc;
-    return tok;
+  [[nodiscard]] static bool isWhitespace(const char c) noexcept {
+    return c == ' ' || c == '\t' || isNewline(c);
+  }
+
+  [[nodiscard]] static bool isNewline(const char c) noexcept {
+    return c == '\n' || c == '\r';
   }
 
   std::string_view input;
@@ -272,7 +271,7 @@ ParseResult parseContract(std::string_view input) {
   Lexer lexer(input);
   const auto tokens = lexer.tokenize(result.errors);
   std::ignore = tokens;
-  //TODO: implement parsing here
+  // TODO: implement parsing here
   return result;
 }
 


### PR DESCRIPTION
## Summary
- Add `Lexer` class that tokenizes ECSL contract comment bodies into `Token` values
- Covers keywords (`requires`/`ensures`/`assigns`), backslash-keywords (`\result`, `\nothing`), identifiers, integer literals, all operators, and punctuation
- Lex errors (unexpected characters, unknown backslash keywords) are collected into `ParseResult::errors`
- `parseContract` now runs the lexer but does not yet parse clauses (returns empty clauses)

Part 2 of 4 replacing #48. Depends on #49.

## Test plan
- [x] `cmake --build build/dev --target ArcanumParser` compiles with no warnings
- [x] `clang-format --dry-run -Werror` clean
- [x] `clang-tidy` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)