### PR TITLE
Add pretty-printing and tests for ECSL parser

### DIFF
--- a/arcanum/parser/ECSLParser.cpp
+++ b/arcanum/parser/ECSLParser.cpp
@@ -1,13 +1,15 @@
 /// \file
 /// ECSL contract comment parser implementation.
-/// This file contains the lexer; the recursive-descent parser and
-/// pretty-printer are added in subsequent commits.
+/// This file contains the lexer and recursive-descent parser; the
+/// pretty-printer is added in a subsequent commit.
 
 #include "parser/ECSLParser.h"
 
 #include <cctype>
 #include <cstddef>
 #include <cstdint>
+#include <memory>
+#include <optional>
 #include <string>
 #include <string_view>
 #include <utility>
@@ -261,6 +263,260 @@ private:
   SourceLoc loc;
 };
 
+//===----------------------------------------------------------------------===//
+// Parser
+//===----------------------------------------------------------------------===//
+
+// Recursive-descent parser: mutually recursive by design.
+// NOLINTBEGIN(misc-no-recursion)
+class Parser {
+public:
+  Parser(std::vector<Token> toks, std::vector<ParseError>& errs)
+      : tokens(std::move(toks)), errors(errs) {}
+
+  std::vector<Clause> parseClauses() {
+    std::vector<Clause> clauses;
+    unsigned index = 0;
+    while (current().kind != TokKind::Eof) {
+      if (auto clause = parseClause(index)) {
+        clauses.push_back(std::move(*clause));
+        ++index;
+      } else {
+        syncToNextClause();
+      }
+    }
+    return clauses;
+  }
+
+private:
+  std::optional<Clause> parseClause(unsigned index) {
+    const Token startTok = current();
+    Clause clause;
+    clause.loc = startTok.loc;
+    clause.index = index;
+
+    if (startTok.kind == TokKind::KwRequires) {
+      clause.kind = ClauseKind::Requires;
+      advance();
+      clause.predicate = parsePredicate();
+    } else if (startTok.kind == TokKind::KwEnsures) {
+      clause.kind = ClauseKind::Ensures;
+      advance();
+      clause.predicate = parsePredicate();
+    } else if (startTok.kind == TokKind::KwAssigns) {
+      clause.kind = ClauseKind::AssignsNothing;
+      advance();
+      if (!expect(TokKind::KwNothing, "expected '\\nothing' after 'assigns'")) {
+        return std::nullopt;
+      }
+    } else {
+      reportAt("expected 'requires', 'ensures', or 'assigns'", startTok.loc);
+      return std::nullopt;
+    }
+
+    if (!expect(TokKind::Semi, "expected ';' at end of clause")) {
+      return std::nullopt;
+    }
+    return clause;
+  }
+
+  // predicate := logical_or
+  ExprPtr parsePredicate() { return parseLogicalOr(); }
+
+  ExprPtr parseLogicalOr() {
+    ExprPtr lhs = parseLogicalAnd();
+    while (current().kind == TokKind::PipePipe) {
+      const SourceLoc loc = current().loc;
+      advance();
+      ExprPtr rhs = parseLogicalAnd();
+      lhs =
+          makeBinary(BinaryOp::LogicalOr, std::move(lhs), std::move(rhs), loc);
+    }
+    return lhs;
+  }
+
+  ExprPtr parseLogicalAnd() {
+    ExprPtr lhs = parseEquality();
+    while (current().kind == TokKind::AmpAmp) {
+      const SourceLoc loc = current().loc;
+      advance();
+      ExprPtr rhs = parseEquality();
+      lhs =
+          makeBinary(BinaryOp::LogicalAnd, std::move(lhs), std::move(rhs), loc);
+    }
+    return lhs;
+  }
+
+  ExprPtr parseEquality() {
+    ExprPtr lhs = parseRelational();
+    while (current().kind == TokKind::EqEq ||
+           current().kind == TokKind::BangEq) {
+      const BinaryOp op =
+          current().kind == TokKind::EqEq ? BinaryOp::Eq : BinaryOp::Ne;
+      const SourceLoc loc = current().loc;
+      advance();
+      ExprPtr rhs = parseRelational();
+      lhs = makeBinary(op, std::move(lhs), std::move(rhs), loc);
+    }
+    return lhs;
+  }
+
+  ExprPtr parseRelational() {
+    ExprPtr lhs = parseAdditive();
+    while (true) {
+      const TokKind k = current().kind;
+      BinaryOp op = BinaryOp::Eq;
+      if (k == TokKind::Lt) {
+        op = BinaryOp::Lt;
+      } else if (k == TokKind::Le) {
+        op = BinaryOp::Le;
+      } else if (k == TokKind::Gt) {
+        op = BinaryOp::Gt;
+      } else if (k == TokKind::Ge) {
+        op = BinaryOp::Ge;
+      } else {
+        return lhs;
+      }
+      const SourceLoc loc = current().loc;
+      advance();
+      ExprPtr rhs = parseAdditive();
+      lhs = makeBinary(op, std::move(lhs), std::move(rhs), loc);
+    }
+  }
+
+  ExprPtr parseAdditive() {
+    ExprPtr lhs = parseMultiplicative();
+    while (current().kind == TokKind::Plus ||
+           current().kind == TokKind::Minus) {
+      const BinaryOp op =
+          current().kind == TokKind::Plus ? BinaryOp::Add : BinaryOp::Sub;
+      const SourceLoc loc = current().loc;
+      advance();
+      ExprPtr rhs = parseMultiplicative();
+      lhs = makeBinary(op, std::move(lhs), std::move(rhs), loc);
+    }
+    return lhs;
+  }
+
+  ExprPtr parseMultiplicative() {
+    ExprPtr lhs = parseUnary();
+    while (true) {
+      const TokKind k = current().kind;
+      BinaryOp op = BinaryOp::Mul;
+      if (k == TokKind::Star) {
+        op = BinaryOp::Mul;
+      } else if (k == TokKind::Slash) {
+        op = BinaryOp::Div;
+      } else if (k == TokKind::Percent) {
+        op = BinaryOp::Mod;
+      } else {
+        return lhs;
+      }
+      const SourceLoc loc = current().loc;
+      advance();
+      ExprPtr rhs = parseUnary();
+      lhs = makeBinary(op, std::move(lhs), std::move(rhs), loc);
+    }
+  }
+
+  ExprPtr parseUnary() {
+    if (current().kind == TokKind::Bang) {
+      const SourceLoc loc = current().loc;
+      advance();
+      return makeUnary(UnaryOp::Not, parseUnary(), loc);
+    }
+    if (current().kind == TokKind::Minus) {
+      const SourceLoc loc = current().loc;
+      advance();
+      return makeUnary(UnaryOp::Neg, parseUnary(), loc);
+    }
+    return parsePrimary();
+  }
+
+  ExprPtr parsePrimary() {
+    const Token tok = current();
+    if (tok.kind == TokKind::Ident) {
+      advance();
+      return makeExpr(Identifier{tok.text}, tok.loc);
+    }
+    if (tok.kind == TokKind::IntLit) {
+      advance();
+      return makeExpr(IntLiteral{tok.text}, tok.loc);
+    }
+    if (tok.kind == TokKind::KwResult) {
+      advance();
+      return makeExpr(ResultExpr{}, tok.loc);
+    }
+    if (tok.kind == TokKind::LParen) {
+      advance();
+      ExprPtr inner = parsePredicate();
+      expect(TokKind::RParen, "expected ')' to close expression");
+      return inner;
+    }
+    reportAt("expected expression, got '" + tok.text + "'", tok.loc);
+    advance();
+    return makeExpr(IntLiteral{"0"}, tok.loc); // error recovery
+  }
+
+  bool expect(TokKind kind, const std::string& message) {
+    if (current().kind == kind) {
+      advance();
+      return true;
+    }
+    reportAt(message, current().loc);
+    return false;
+  }
+
+  void syncToNextClause() {
+    while (current().kind != TokKind::Eof) {
+      if (current().kind == TokKind::Semi) {
+        advance();
+        return;
+      }
+      advance();
+    }
+  }
+
+  void reportAt(std::string message, SourceLoc loc) {
+    errors.push_back({std::move(message), loc});
+  }
+
+  [[nodiscard]] const Token& current() const { return tokens[cursor]; }
+
+  void advance() {
+    if (tokens[cursor].kind != TokKind::Eof) {
+      ++cursor;
+    }
+  }
+
+  static ExprPtr makeBinary(BinaryOp op, ExprPtr lhs, ExprPtr rhs,
+                            SourceLoc loc) {
+    auto expr = std::make_unique<Expr>();
+    expr->node = BinaryExpr{op, std::move(lhs), std::move(rhs)};
+    expr->loc = loc;
+    return expr;
+  }
+
+  static ExprPtr makeUnary(UnaryOp op, ExprPtr operand, SourceLoc loc) {
+    auto expr = std::make_unique<Expr>();
+    expr->node = UnaryExpr{op, std::move(operand)};
+    expr->loc = loc;
+    return expr;
+  }
+
+  template <typename T> static ExprPtr makeExpr(T node, SourceLoc loc) {
+    auto expr = std::make_unique<Expr>();
+    expr->node = std::move(node);
+    expr->loc = loc;
+    return expr;
+  }
+
+  std::vector<Token> tokens;
+  std::vector<ParseError>& errors;
+  std::size_t cursor = 0;
+};
+// NOLINTEND(misc-no-recursion)
+
 } // namespace
 
 //===----------------------------------------------------------------------===//
@@ -270,7 +526,9 @@ private:
 ParseResult parseContract(std::string_view input) {
   ParseResult result;
   Lexer lexer(input);
-  lexer.tokenize(result.errors);
+  auto tokens = lexer.tokenize(result.errors);
+  Parser parser(std::move(tokens), result.errors);
+  result.clauses = parser.parseClauses();
   return result;
 }
 

--- a/arcanum/parser/ECSLParser.cpp
+++ b/arcanum/parser/ECSLParser.cpp
@@ -1,7 +1,6 @@
 /// \file
 /// ECSL contract comment parser implementation.
-/// This file contains the lexer and recursive-descent parser; the
-/// pretty-printer is added in a subsequent commit.
+/// Contains the lexer, recursive-descent parser, and pretty-printer.
 
 #include "parser/ECSLParser.h"
 
@@ -10,9 +9,12 @@
 #include <cstdint>
 #include <memory>
 #include <optional>
+#include <sstream>
 #include <string>
 #include <string_view>
+#include <type_traits>
 #include <utility>
+#include <variant>
 #include <vector>
 
 namespace arcanum::parser {
@@ -517,6 +519,92 @@ private:
 };
 // NOLINTEND(misc-no-recursion)
 
+//===----------------------------------------------------------------------===//
+// Pretty-printing
+//===----------------------------------------------------------------------===//
+
+const char* binaryOpSpelling(BinaryOp op) {
+  switch (op) {
+  case BinaryOp::Eq:
+    return "==";
+  case BinaryOp::Ne:
+    return "!=";
+  case BinaryOp::Lt:
+    return "<";
+  case BinaryOp::Le:
+    return "<=";
+  case BinaryOp::Gt:
+    return ">";
+  case BinaryOp::Ge:
+    return ">=";
+  case BinaryOp::Add:
+    return "+";
+  case BinaryOp::Sub:
+    return "-";
+  case BinaryOp::Mul:
+    return "*";
+  case BinaryOp::Div:
+    return "/";
+  case BinaryOp::Mod:
+    return "%";
+  case BinaryOp::LogicalAnd:
+    return "&&";
+  case BinaryOp::LogicalOr:
+    return "||";
+  }
+  return "?";
+}
+
+const char* unaryOpSpelling(UnaryOp op) {
+  switch (op) {
+  case UnaryOp::Neg:
+    return "-";
+  case UnaryOp::Not:
+    return "!";
+  }
+  return "?";
+}
+
+// Expression printing recurses through nested Binary / Unary nodes.
+// NOLINTBEGIN(misc-no-recursion)
+void printExpr(std::ostringstream& out, const Expr& expr) {
+  std::visit(
+      [&out](const auto& node) {
+        using T = std::decay_t<decltype(node)>;
+        if constexpr (std::is_same_v<T, Identifier>) {
+          out << node.name;
+        } else if constexpr (std::is_same_v<T, IntLiteral>) {
+          out << node.text;
+        } else if constexpr (std::is_same_v<T, ResultExpr>) {
+          out << "\\result";
+        } else if constexpr (std::is_same_v<T, BinaryExpr>) {
+          out << "(" << binaryOpSpelling(node.op) << " ";
+          printExpr(out, *node.lhs);
+          out << " ";
+          printExpr(out, *node.rhs);
+          out << ")";
+        } else if constexpr (std::is_same_v<T, UnaryExpr>) {
+          out << "(" << unaryOpSpelling(node.op) << " ";
+          printExpr(out, *node.operand);
+          out << ")";
+        }
+      },
+      expr.node);
+}
+// NOLINTEND(misc-no-recursion)
+
+const char* clauseKindSpelling(ClauseKind kind) {
+  switch (kind) {
+  case ClauseKind::Requires:
+    return "requires";
+  case ClauseKind::Ensures:
+    return "ensures";
+  case ClauseKind::AssignsNothing:
+    return "assigns \\nothing";
+  }
+  return "?";
+}
+
 } // namespace
 
 //===----------------------------------------------------------------------===//
@@ -532,8 +620,20 @@ ParseResult parseContract(std::string_view input) {
   return result;
 }
 
-std::string toString(const Expr& /*expr*/) { return {}; }
+std::string toString(const Expr& expr) {
+  std::ostringstream out;
+  printExpr(out, expr);
+  return out.str();
+}
 
-std::string toString(const Clause& /*clause*/) { return {}; }
+std::string toString(const Clause& clause) {
+  std::ostringstream out;
+  out << "[" << clause.index << "] " << clauseKindSpelling(clause.kind);
+  if (clause.predicate) {
+    out << " ";
+    printExpr(out, *clause.predicate);
+  }
+  return out.str();
+}
 
 } // namespace arcanum::parser

--- a/arcanum/test/CMakeLists.txt
+++ b/arcanum/test/CMakeLists.txt
@@ -2,6 +2,7 @@
 
 # --- Unit tests (C++ executables, run via CTest) ---
 add_subdirectory(ecsl)
+add_subdirectory(parser)
 add_subdirectory(testgen)
 add_subdirectory(tools)
 

--- a/arcanum/test/parser/CMakeLists.txt
+++ b/arcanum/test/parser/CMakeLists.txt
@@ -1,0 +1,14 @@
+# test/parser/ - Parser unit tests
+
+add_executable(arcanum-test-ecsl-parser
+  ECSLParserTest.cpp
+)
+
+target_link_libraries(arcanum-test-ecsl-parser
+  PRIVATE
+  ArcanumParser
+)
+
+add_test(NAME ecsl-parser
+  COMMAND arcanum-test-ecsl-parser
+)

--- a/arcanum/test/parser/ECSLParserTest.cpp
+++ b/arcanum/test/parser/ECSLParserTest.cpp
@@ -1,0 +1,75 @@
+// Unit test for arcanum::parser::parseContract: parses a handful of
+// representative ECSL contract bodies and checks the pretty-printed
+// AST against expected strings.
+
+#include "parser/ECSLParser.h"
+
+#include <array>
+#include <iostream>
+#include <string>
+#include <string_view>
+
+namespace {
+
+struct Case {
+  std::string_view name;
+  std::string_view input;
+  std::string_view expected;
+};
+
+bool run(const Case &c) {
+  const arcanum::parser::ParseResult result =
+      arcanum::parser::parseContract(c.input);
+  std::string actual;
+  for (const auto &err : result.errors) {
+    actual += "error@" + std::to_string(err.loc.line) + ":" +
+              std::to_string(err.loc.col) + ": " + err.message + "\n";
+  }
+  for (const auto &clause : result.clauses) {
+    actual += toString(clause);
+    actual += "\n";
+  }
+  if (actual != std::string(c.expected)) {
+    std::cerr << "FAIL: " << c.name << "\n"
+              << "  input:    " << c.input << "\n"
+              << "  expected: |" << c.expected << "|\n"
+              << "  actual:   |" << actual << "|\n";
+    return false;
+  }
+  return true;
+}
+
+} // namespace
+
+int main() {
+  const std::array<Case, 9> cases{{
+      {"single_requires", "requires x >= 0;", "[0] requires (>= x 0)\n"},
+      {"single_ensures_with_result", "ensures \\result >= 0;",
+       "[0] ensures (>= \\result 0)\n"},
+      {"assigns_nothing", "assigns \\nothing;", "[0] assigns \\nothing\n"},
+      {"multiple_clauses",
+       "requires x > 0; requires y > 0; ensures \\result == x + y;",
+       "[0] requires (> x 0)\n"
+       "[1] requires (> y 0)\n"
+       "[2] ensures (== \\result (+ x y))\n"},
+      {"precedence", "requires a + b * c <= d;",
+       "[0] requires (<= (+ a (* b c)) d)\n"},
+      {"logical_connectives", "requires x > 0 && (y > 0 || z == 0);",
+       "[0] requires (&& (> x 0) (|| (> y 0) (== z 0)))\n"},
+      {"unary_not_and_neg", "requires !(x == 0) && y == -1;",
+       "[0] requires (&& (! (== x 0)) (== y (- 1)))\n"},
+      {"error_missing_semicolon", "requires x > 0",
+       "error@1:15: expected ';' at end of clause\n"},
+      {"error_bad_token", "requires x & y;",
+       "error@1:12: unexpected '&'\n"
+       "error@1:14: expected ';' at end of clause\n"},
+  }};
+
+  bool allPassed = true;
+  for (const auto &c : cases) {
+    if (!run(c)) {
+      allPassed = false;
+    }
+  }
+  return allPassed ? 0 : 1;
+}


### PR DESCRIPTION
## Summary
- Implement `toString(Expr)` and `toString(Clause)` using S-expression format for deterministic test output
- Add `binaryOpSpelling`, `unaryOpSpelling`, `clauseKindSpelling` helper functions and recursive `printExpr` visitor
- Add 9 unit tests: atoms, precedence, logical connectives, unary ops, and 2 error paths

Part 4 of 4 replacing #48. Depends on #51. Closes #9.

## Test plan
- [x] `ctest -R ecsl-parser` passes (all 9 cases)
- [x] `cmake --build build/dev` compiles with no warnings
- [x] `clang-format --dry-run -Werror` clean
- [x] `clang-tidy` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)